### PR TITLE
Resolve issue #34 via eager loading of country in Region.

### DIFF
--- a/src/main/resources/hibernate/region.hbm.xml
+++ b/src/main/resources/hibernate/region.hbm.xml
@@ -14,6 +14,6 @@
             <column length="45" name="DESCRIPTION" not-null="true">
             </column>
         </property>
-        <many-to-one cascade="all" class="org.haftrust.verifier.model.Country" column="HT_COUNTRY_IDCOUNTRY" name="country" not-null="true"/>
+        <many-to-one cascade="all" class="org.haftrust.verifier.model.Country" column="HT_COUNTRY_IDCOUNTRY" name="country" not-null="true" lazy="false"/>
     </class>
 </hibernate-mapping>


### PR DESCRIPTION
Issue #34 is caused by the `toString()` method in `Region` attempting to concatenate the region's country. The country is a separate entity, which has not been loaded. Given that the `toString()` method has been written to assume that the country has been loaded, the simplest fix is to eager-load the country when the region is loaded.

An alternative is to add the `OpenSessionInViewFilter` to the filter chain, to ensure that Hibernate sessions are maintained open throughout the lifetime of a view.