### PR TITLE
Issue #39 - Removed trailing space from "Registered " employment status

### DIFF
--- a/src/main/resources/db_script.sql
+++ b/src/main/resources/db_script.sql
@@ -220,7 +220,7 @@ INSERT INTO KJ905.HT_STATIC_DATA ("TYPE", "VALUE", DESCRIPTION) VALUES ('educati
 INSERT INTO KJ905.HT_STATIC_DATA ("TYPE", "VALUE", DESCRIPTION) VALUES ('education type', 'type 1', 'Type 1');
 INSERT INTO KJ905.HT_STATIC_DATA ("TYPE", "VALUE", DESCRIPTION) VALUES ('education type', 'type 2', 'Type 2');
 INSERT INTO KJ905.HT_STATIC_DATA ("TYPE", "VALUE", DESCRIPTION) VALUES ('employment status', 'preregistered', 'Preregistered');
-INSERT INTO KJ905.HT_STATIC_DATA ("TYPE", "VALUE", DESCRIPTION) VALUES ('employment status', 'registered', 'Registered ');
+INSERT INTO KJ905.HT_STATIC_DATA ("TYPE", "VALUE", DESCRIPTION) VALUES ('employment status', 'registered', 'Registered');
 INSERT INTO KJ905.HT_STATIC_DATA ("TYPE", "VALUE", DESCRIPTION) VALUES ('employment status', 'verified', 'Verified');
 INSERT INTO KJ905.HT_STATIC_DATA ("TYPE", "VALUE", DESCRIPTION) VALUES ('employment status', 'employed', 'Employed');
 INSERT INTO KJ905.HT_STATIC_DATA ("TYPE", "VALUE", DESCRIPTION) VALUES ('employment status', 'failed', 'Failed');


### PR DESCRIPTION
Some kind of standardized exception handling around requested resources not found would be good, rather than blowing up with an 'index out of bounds'. However, this fixes the specific issue causing the bug, which was just an error in the database load script.