### PR TITLE
Issue #8 - Initial migration to Spring 3.2.9.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <spring.version>2.5.6.SEC03</spring.version>
+        <spring.version>3.2.9.RELEASE</spring.version>
         <selenium.version>2.44.0</selenium.version>
         <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
     </properties>


### PR DESCRIPTION
Key benefit is that this provides access to `@Controller` annotations, which should enable gradual removal of `AbstractWizardFormController`, which is blocking migration to Spring 4.x. Project builds and I have been able to access all of the pages without seeing any errors that I wasn't seeing already.