### PR TITLE
Resolve issue #47 via eager loading of Region in District.

### DIFF
--- a/src/main/resources/hibernate/district.hbm.xml
+++ b/src/main/resources/hibernate/district.hbm.xml
@@ -14,6 +14,6 @@
             <column length="45" name="DESCRIPTION" not-null="true">
             </column>
         </property>
-        <many-to-one cascade="all" class="org.haftrust.verifier.model.Region" column="HT_REGION_IDREGION" name="region" not-null="true"/>
+        <many-to-one cascade="all" class="org.haftrust.verifier.model.Region" column="HT_REGION_IDREGION" name="region" not-null="true" lazy="false"/>
     </class>
 </hibernate-mapping>


### PR DESCRIPTION
Issue #47 is caused by the toString() method in District attempting to concatenate the region. The region is a separate entity, which has not been loaded. Given that the toString() method has been written to assume that the region has been loaded, the simplest fix is to eager-load the region when the district is loaded.