### PR TITLE
TravisCI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+  - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -409,8 +409,8 @@
     </issueManagement>
 
     <ciManagement>
-        <system>TODO</system>
-        <url>https://localhost/</url>
+        <system>TravisCI</system>
+        <url>https://travis-ci.org/kittylyst/VillagePaymentAgent</url>
     </ciManagement>
 
     <licenses>


### PR DESCRIPTION
To get started with Travis CI, sign in with your GitHub account.
Once you're signed in, and travisci has initially synchronized your repositories from GitHub, go to your profile section (https://travis-ci.org/profile)
and flip switch to on for kittylyst/VillagePaymentAgent.
CI section in the pom file is updated with the expected url.