### PR TITLE
Removing call to Throwable.printStackTrace()

### DIFF
--- a/src/main/java/org/haftrust/verifier/validator/IdentityDocumentValidator.java
+++ b/src/main/java/org/haftrust/verifier/validator/IdentityDocumentValidator.java
@@ -118,8 +118,8 @@ public class IdentityDocumentValidator implements Validator {
                 if (currentDate.after(gcExpiryDate)) {
                     errors.rejectValue("identityDocumentExpiryDate", "required.identityDocumentExpiryDate", "The Expiry Date has to be after the current date.");
                 }
-            } catch (Exception e) {
-                e.printStackTrace();
+            } catch (Exception exception) {
+                LOG.warn("The expiry date has to be after the current date.", exception);
             }
         }
 

--- a/src/main/java/org/haftrust/verifier/validator/IdentityDocumentValidator.java
+++ b/src/main/java/org/haftrust/verifier/validator/IdentityDocumentValidator.java
@@ -132,8 +132,8 @@ public class IdentityDocumentValidator implements Validator {
                 if (gc.after(gcExpiryDate)) {
                     errors.rejectValue("identityDocumentExpiryDate", "required.identityDocumentExpiryDate", "The Expiry Date has to be at least one year after the Issue Date.");
                 }
-            } catch (Exception e) {
-                e.printStackTrace();
+            } catch (Exception exception) {
+                LOG.warn("The expiry date has to be at least one year after the issue date.", exception);
             }
         }
     }

--- a/src/main/java/org/haftrust/verifier/validator/IdentityDocumentValidator.java
+++ b/src/main/java/org/haftrust/verifier/validator/IdentityDocumentValidator.java
@@ -93,10 +93,10 @@ public class IdentityDocumentValidator implements Validator {
             gcExpiryDate.set(GregorianCalendar.DATE, expiryDateDay);
 
             gc.getTime(); // exception thrown here
-        } catch (Exception e) {
+        } catch (Exception exception) {
             expiryDateOK = false;
             errors.rejectValue("identityDocumentExpiryDate", "required.identityDocumentExpiryDate", "Expiry Date is invalid.");
-            e.printStackTrace();
+            LOG.warn("Expiry date is invalid.", exception);
         }
 
         GregorianCalendar currentDate = new GregorianCalendar();

--- a/src/main/java/org/haftrust/verifier/validator/IdentityDocumentValidator.java
+++ b/src/main/java/org/haftrust/verifier/validator/IdentityDocumentValidator.java
@@ -108,8 +108,8 @@ public class IdentityDocumentValidator implements Validator {
                 if (currentDate.before(gc)) {
                     errors.rejectValue("identityDocumentIssueDate", "required.identityDocumentIssueDate", "The Issue Date has to be before the current date.");
                 }
-            } catch (Exception e) {
-                e.printStackTrace();
+            } catch (Exception exception) {
+                LOG.warn("The issue date has to be before the current date.", exception);
             }
         }
 

--- a/src/main/java/org/haftrust/verifier/validator/IdentityDocumentValidator.java
+++ b/src/main/java/org/haftrust/verifier/validator/IdentityDocumentValidator.java
@@ -76,10 +76,10 @@ public class IdentityDocumentValidator implements Validator {
             gc.set(GregorianCalendar.DATE, day);
 
             gc.getTime(); // exception thrown here
-        } catch (Exception e) {
+        } catch (Exception exception) {
             issueDateOK = false;
             errors.rejectValue("identityDocumentIssueDate", "required.identityDocumentIssueDate", "Issue Date is invalid.");
-            e.printStackTrace();
+            LOG.warn("Issue date is invalid.", exception);
         }
 
         GregorianCalendar gcExpiryDate = new GregorianCalendar();

--- a/src/main/java/org/haftrust/verifier/validator/VerifierValidator.java
+++ b/src/main/java/org/haftrust/verifier/validator/VerifierValidator.java
@@ -107,10 +107,10 @@ public class VerifierValidator implements Validator {
                 if (currentDate.before(gc)) {
                     errors.rejectValue("dob", "required.dob", "The Verifier has to be over 23 years old.");
                 }
-            } catch (Exception e) {
+            } catch (Exception exception) {
                 //dobOK = false;
                 //errors.rejectValue("dob", "required.dob", "Date of Birth is invalid.");
-                e.printStackTrace();
+                LOG.warn("Have to older than 23 years old.", exception);
             }
         }
 

--- a/src/main/java/org/haftrust/verifier/validator/VerifierValidator.java
+++ b/src/main/java/org/haftrust/verifier/validator/VerifierValidator.java
@@ -88,10 +88,10 @@ public class VerifierValidator implements Validator {
             gc.set(GregorianCalendar.DATE, day);
 
             gc.getTime(); // exception thrown here
-        } catch (Exception e) {
+        } catch (Exception exception) {
             dobOK = false;
             errors.rejectValue("dob", "required.dob", "Date of Birth is invalid.");
-            e.printStackTrace();
+            LOG.warn("Date of birth is invalid.", exception);
         }
 
         if (dobOK) {

--- a/src/main/java/org/haftrust/verifier/validator/VerifierValidator.java
+++ b/src/main/java/org/haftrust/verifier/validator/VerifierValidator.java
@@ -108,8 +108,6 @@ public class VerifierValidator implements Validator {
                     errors.rejectValue("dob", "required.dob", "The Verifier has to be over 23 years old.");
                 }
             } catch (Exception exception) {
-                //dobOK = false;
-                //errors.rejectValue("dob", "required.dob", "Date of Birth is invalid.");
                 LOG.warn("Have to older than 23 years old.", exception);
             }
         }


### PR DESCRIPTION
Instead logging it as a warning from VerifierValidator.